### PR TITLE
Fix rusage

### DIFF
--- a/drmaa/helpers.py
+++ b/drmaa/helpers.py
@@ -231,11 +231,15 @@ def attributes_iterator(attributes):
 
 def adapt_rusage(rusage):
     """
-    transform a rusage data structure into a dict
+    Transform a rusage data structure into a dict.
+
+    Due to the value possibly containing a equal sign make sure we
+    limit the splits to only the first occurrence.
     """
     rv = dict()
     for attr in attributes_iterator(rusage.contents):
-        k, v = attr.split('=')
+        
+        k, v = attr.split('=',1)
         rv[k] = v
     return rv
 

--- a/drmaa/version.py
+++ b/drmaa/version.py
@@ -22,5 +22,5 @@ in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 :author: Dan Blanchard (dblanchard@ets.org)
 '''
 
-__version__ = '0.7.6'
+__version__ = '0.7.7'
 VERSION = tuple(int(x) for x in __version__.split('.'))


### PR DESCRIPTION
This should fix an issues reported in issue #22 where with PBS Pro 12.2 and pbs-drmaa we can get the following error:
```bash
68275.server
Your job has been submitted with id 68275.server
Traceback (most recent call last):
  File "ex3.py", line 36, in <module>
    main()
  File "ex3.py", line 26, in main
    retval = s.wait(jobid, drmaa.Session.TIMEOUT_WAIT_FOREVER)
  File "/home/user/drmaa_example/test_git/drmaa/session.py", line 472, in wait
    res_usage = adapt_rusage(rusage)
  File "/home/user/drmaa_example/test_git/drmaa/helpers.py", line 238, in adapt_rusage
    k, v = attr.split('=')
ValueError: too many values to unpack
```
With fix then it correctly works.
```bash
68277.server
Your job has been submitted with id 68277.server
Job: 68277.server finished with status True
Job status = done
Cleaning up
```
