### PR TITLE
Fix erroneous drmaa_wcoredump and drmaa_wtermsig calls

### DIFF
--- a/drmaa/session.py
+++ b/drmaa/session.py
@@ -477,11 +477,13 @@ class Session(object):
         signaled = c_int()
         c(drmaa_wifsignaled, byref(signaled), stat)
         coredumped = c_int()
-        c(drmaa_wcoredump, byref(coredumped), stat)
+        if exited.value == 0:
+            c(drmaa_wcoredump, byref(coredumped), stat)
         exit_status = c_int()
         c(drmaa_wexitstatus, byref(exit_status), stat)
         term_signal = create_string_buffer(SIGNAL_BUFFER)
-        c(drmaa_wtermsig, term_signal, sizeof(term_signal), stat)
+        if signaled.value == 1:
+            c(drmaa_wtermsig, term_signal, sizeof(term_signal), stat)
         return JobInfo(jid_out.value.decode(), bool(exited), bool(signaled),
                        term_signal.value.decode(), bool(coredumped),
                        bool(aborted), int(exit_status.value), res_usage)


### PR DESCRIPTION
fixes calls to `drmaa_wcoredump` and `drmaa_wtermsig` when the job exited normally to fix error when used with condor libdrmaa lib drmaa specifies these calls are only to be made when the job exited abnormally or signaled.

from the drmaa.h file it is clear this is how these calls are supposet to be treated:

```
/** Returns the name of the signal that terminated the process if the drmaa_wifsignaled() returned non-zero.*/
  int drmaa_wtermsig (char *signal, size_t signal_len, int stat,
		      char *error_diagnosis, size_t error_diag_len);
````

```
/** Evalutes core_dumped to non-zero if status was returned for a job that terminated and core_dumped.*/
  int drmaa_wcoredump (int *core_dumped, int stat, char *error_diagnosis,
		       size_t error_diag_len);
```

### Fixes: #21 drmaa-python wait not playing nice with Condor