### PR TITLE
Replace Google Code URL with GitHub/PyPI URLs

### DIFF
--- a/drmaa/__init__.py
+++ b/drmaa/__init__.py
@@ -21,8 +21,10 @@
 A python package for DRM job submission and control.
 
 This package is an implementation of the DRMAA 1.0 Python language
-binding specification (http://www.ogf.org/documents/GFD.143.pdf).  See
-http://drmaa-python.googlecode.com for package info and download.
+binding specification (http://www.ogf.org/documents/GFD.143.pdf).
+The source is hosted on GitHub: https://github.com/pygridtools/drmaa-python
+Releases are available on GitHub: https://github.com/drmaa-python/drmaa-python/releases
+Documentation is hosted on ReadTheDocs: http://drmaa-python.readthedocs.org/
 
 :author: Enrico Sirola (enrico.sirola@statpro.com)
 :author: Dan Blanchard (dblanchard@ets.org)

--- a/drmaa/__init__.py
+++ b/drmaa/__init__.py
@@ -23,7 +23,7 @@ A python package for DRM job submission and control.
 This package is an implementation of the DRMAA 1.0 Python language
 binding specification (http://www.ogf.org/documents/GFD.143.pdf).
 The source is hosted on GitHub: https://github.com/pygridtools/drmaa-python
-Releases are available on GitHub: https://github.com/drmaa-python/drmaa-python/releases
+Releases are available from PyPi: https://pypi.python.org/pypi/drmaa
 Documentation is hosted on ReadTheDocs: http://drmaa-python.readthedocs.org/
 
 :author: Enrico Sirola (enrico.sirola@statpro.com)


### PR DESCRIPTION
AFAICT the DRMAA bindings for Python are no longer hosted on Google Code.