### PR TITLE
Cannot build sphinx docs without disabling sphinx.ext.pngmath extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ import drmaa
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage',
-              'sphinx.ext.pngmath', 'sphinx.ext.mathjax', 'sphinx.ext.viewcode']
+              'sphinx.ext.mathjax', 'sphinx.ext.viewcode']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Tried to build docs and got the following:
```
$ make -j4 html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.5.4
making output directory...
WARNING: sphinx.ext.pngmath has been deprecated. Please use sphinx.ext.imgmath instead.

Extension error:
sphinx.ext.mathjax: other math package is already loaded
```
This can be addressed by removing the `sphinx.ext.pngmath` extension from the Sphinx config.