### PR TITLE
Use `finally` in `run_bulk_job` and catch StopIteration

### DIFF
--- a/drmaa/helpers.py
+++ b/drmaa/helpers.py
@@ -288,10 +288,7 @@ def run_bulk_job(jt, start, end, incr=1):
         while drmaa_get_next_job_id(jids.contents, jid,
                                     _BUFLEN) != NO_MORE_ELEMENTS:
             yield jid.value.decode()
-    except:
-        drmaa_release_job_ids(jids.contents)
-        raise
-    else:
+    finally:
         drmaa_release_job_ids(jids.contents)
 
 

--- a/drmaa/helpers.py
+++ b/drmaa/helpers.py
@@ -288,6 +288,8 @@ def run_bulk_job(jt, start, end, incr=1):
         while drmaa_get_next_job_id(jids.contents, jid,
                                     _BUFLEN) != NO_MORE_ELEMENTS:
             yield jid.value.decode()
+    except StopIteration:
+        pass
     finally:
         drmaa_release_job_ids(jids.contents)
 


### PR DESCRIPTION
Fixes https://github.com/pygridtools/drmaa-python/issues/54

Previously this code was using `except` and `else` to do the same handling. Better to just use `finally` in this case, which is what we do here.

Also squash a `StopIteration` exception that is not otherwise caught. Not totally sure how it was getting raised in the first place, but catching it avoids a `DeprecationWarning` and has no real other effect for the code.

cc @pitrou