### PR TITLE
Require Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os: linux
+dist: precise
+
 language: python
 python:
   - 2.6


### PR DESCRIPTION
Travis CI has made the default Ubuntu Trusty and will soon eliminate Ubuntu Precise. For now, require Ubuntu Precise. At some point this will need to be rewritten to use Ubuntu Trusty or will need a Docker container that can mimic the original system for testing.