### PR TITLE
Start testing against Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - export SGE_ROOT=/var/lib/gridengine
   - export SGE_CELL=default
   - export DRMAA_LIBRARY_PATH=/usr/lib/libdrmaa.so.1.0
-  - pip install --upgrade pip
+  - pip install --upgrade pip setuptools
 install:
   - pip install python-coveralls
   - pip install nose-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.6-dev
+  - 3.7-dev
 
 sudo: required
 


### PR DESCRIPTION
Adds the Python 3.7 dev release as a target of the testing matrix on Travis CI.