### PR TITLE
Drop Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: precise
 
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ If you simply want to run Python functions on a DRMAA-compatible grid, use
 Requirements
 ~~~~~~~~~~~~
 
--  Python 2.6+
+-  Python 2.7+
 -  A DRMAA-compatible cluster (e.g., Grid Engine)
 
 Installation


### PR DESCRIPTION
Fixes https://github.com/pygridtools/drmaa-python/issues/71

As Python 2.6 has passed its EOL (back in 2013), go ahead and drop it.