### PR TITLE
Drop Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6


### PR DESCRIPTION
Python 3.3's EOL was last September. So drop support for it.