### PR TITLE
Ignore attributes which are empty strings

### DIFF
--- a/drmaa/helpers.py
+++ b/drmaa/helpers.py
@@ -238,7 +238,8 @@ def adapt_rusage(rusage):
     """
     rv = dict()
     for attr in attributes_iterator(rusage.contents):
-
+        if attr == '':
+            continue
         k, v = attr.split('=',1)
         rv[k] = v
     return rv


### PR DESCRIPTION
When using drmaa with condor I find that aborted jobs often (always?) end up with an empty string in the rusage data structure causing `attr.split('=',1)` to crash. I'm not sure if this is a bug in the DRMAA implementation I'm using but this works around the issue and shouldn't have any other side effects.